### PR TITLE
road-outline のスタイルを修正

### DIFF
--- a/layers/components/road-blur-opacity.yml
+++ b/layers/components/road-blur-opacity.yml
@@ -1,0 +1,9 @@
+  - interpolate
+  - - linear
+  - - zoom
+  - 14
+  - 0.2
+  - 17
+  - 0.8
+  - 18
+  - 0

--- a/layers/components/road-color.yml
+++ b/layers/components/road-color.yml
@@ -1,0 +1,7 @@
+  - interpolate
+  - - linear
+  - - zoom
+  - 15
+  - '#ffffff'
+  - 16
+  - '#f5f5f5'

--- a/layers/components/road-opacity.yml
+++ b/layers/components/road-opacity.yml
@@ -1,0 +1,7 @@
+  - interpolate
+  - - linear
+  - - zoom
+  - 15
+  - 1
+  - 16
+  - 0.3

--- a/layers/highway-minor-bridge-casing-blur.yml
+++ b/layers/highway-minor-bridge-casing-blur.yml
@@ -39,12 +39,7 @@ paint:
         - [0, 0]
       - - 17
         - [5, 2]
-  line-opacity:
-    stops:
-      - - 14
-        - 0.2
-      - - 17
-        - 0.8
+  line-opacity: !!inc/file layers/components/road-blur-opacity.yml
   line-blur:
     stops:
       - - 14

--- a/layers/highway-minor-bridge.yml
+++ b/layers/highway-minor-bridge.yml
@@ -25,7 +25,7 @@ filter:
     - rdCtg
     - 3
 paint:
-  line-color: '#cba'
+  line-color: !!inc/file layers/components/road-color.yml
   line-width:
     base: 1.2
     stops:

--- a/layers/highway-minor.yml
+++ b/layers/highway-minor.yml
@@ -17,7 +17,8 @@ layout:
   line-cap: round
   line-join: round
 paint:
-  line-color: '#ffffff'
+  line-opacity: !!inc/file layers/components/road-opacity.yml
+  line-color: !!inc/file layers/components/road-color.yml
   line-width:
     - interpolate
     - - exponential

--- a/layers/highway-primary-bridge-casing-blur.yml
+++ b/layers/highway-primary-bridge-casing-blur.yml
@@ -43,12 +43,7 @@ paint:
         - [0, 0]
       - - 17
         - [5, 2]
-  line-opacity:
-    stops:
-      - - 14
-        - 0.2
-      - - 17
-        - 0.8
+  line-opacity: !!inc/file layers/components/road-blur-opacity.yml
   line-blur:
     stops:
       - - 14

--- a/layers/highway-primary-bridge.yml
+++ b/layers/highway-primary-bridge.yml
@@ -34,5 +34,5 @@ filter:
 layout:
   line-join: round
 paint:
-  line-color: "rgba(255, 255, 255, 1)"
+  line-color: !!inc/file layers/components/road-color.yml
   line-width: !!inc/file layers/components/broad-road-width.yml

--- a/layers/highway-primary.yml
+++ b/layers/highway-primary.yml
@@ -39,5 +39,6 @@ layout:
   line-cap: round
   line-join: round
 paint:
-  line-color: '#fff'
+  line-opacity: !!inc/file layers/components/road-opacity.yml
+  line-color: !!inc/file layers/components/road-color.yml
   line-width: !!inc/file layers/components/broad-road-width.yml

--- a/layers/highway-secondary-bridge-casing-blur.yml
+++ b/layers/highway-secondary-bridge-casing-blur.yml
@@ -45,12 +45,7 @@ paint:
         - [0, 0]
       - - 17
         - [5, 2]
-  line-opacity:
-    stops:
-      - - 14
-        - 0.2
-      - - 17
-        - 0.8
+  line-opacity: !!inc/file layers/components/road-blur-opacity.yml
   line-blur:
     stops:
       - - 14

--- a/layers/highway-secondary-bridge.yml
+++ b/layers/highway-secondary-bridge.yml
@@ -37,5 +37,5 @@ filter:
 layout:
   line-join: round
 paint:
-  line-color: rgba(255, 255, 255, 1)
+  line-color: !!inc/file layers/components/road-color.yml
   line-width: !!inc/file layers/components/broad-road-width.yml

--- a/layers/highway-secondary.yml
+++ b/layers/highway-secondary.yml
@@ -40,5 +40,6 @@ layout:
   line-join: round
   visibility: visible
 paint:
-  line-color: '#fff'
+  line-opacity: !!inc/file layers/components/road-opacity.yml
+  line-color: !!inc/file layers/components/road-color.yml
   line-width: !!inc/file layers/components/broad-road-width.yml


### PR DESCRIPTION
road-outline より、道路の中心線が目立っていたので、

高ズーム時に、道路の中心線の色を背景色と同じになるよう変更。それにより、road-outline が道の輪郭として認識できるようになった。