### PR TITLE
道の色をz16で切り替え

### DIFF
--- a/layers/components/road-color.yml
+++ b/layers/components/road-color.yml
@@ -1,7 +1,5 @@
-  - interpolate
-  - - linear
+  - step
   - - zoom
-  - 15
   - '#ffffff'
   - 16
   - '#f5f5f5'


### PR DESCRIPTION
@marcofabrika 
Fix https://github.com/geoloniamaps/gsi/issues/62

段階的に色を変えるのではなく、step を使って z16 以降 は `#f5f5f5`、以前は `#ffffff` を道の色にすることで解決しました。
確認お願いしても良いでしょうか？