### PR TITLE
高速道路の上に道路枠線が乗っていたので、レイヤー順を修正

### DIFF
--- a/style.yml
+++ b/style.yml
@@ -85,9 +85,9 @@ layers:
   - !!inc/file layers/highway-minor.yml
   - !!inc/file layers/highway-secondary.yml
   - !!inc/file layers/highway-primary.yml
+  - !!inc/file layers/road-outline.yml
   - !!inc/file layers/highway-motorway.yml
 
-  - !!inc/file layers/road-outline.yml
   - !!inc/file layers/building.yml
   - !!inc/file layers/structurea-casing.yml
   - !!inc/file layers/structurea.yml


### PR DESCRIPTION
高速道路の上に道路枠線が乗っていたので、レイヤー順を修正しました。

https://geoloniamaps.github.io/gsi/#19.56/34.700756/135.4913583/12.3

![スクリーンショット 2022-05-31 13 33 37](https://user-images.githubusercontent.com/8760841/171093494-b45e3eb8-4fac-4325-8673-48a984923837.png)

