### PR TITLE
Fix railway label minzoom

### DIFF
--- a/layers/railway-label.yml
+++ b/layers/railway-label.yml
@@ -2,7 +2,7 @@ id: railway-label
 type: symbol
 source: gsi-japan
 source-layer: label
-minzoom: 9
+minzoom: 10
 maxzoom: 15
 filter:
   - all


### PR DESCRIPTION
Close #65 

鉄道名ラベルの minzoom をrailway-jr と railway-secondary のminzoom に合わせて調整しました。

https://deploy-preview-66--style-gsi.netlify.app/#9.96/43.4267/142.4714