### PR TITLE
地名の maxzoom を調整

### DIFF
--- a/layers/place-city-capital.yml
+++ b/layers/place-city-capital.yml
@@ -2,6 +2,7 @@ id: place-city-capital
 type: symbol
 source: geolonia-gsi-custom
 source-layer: place
+maxzoom: 11
 filter:
   - all
   - - '=='

--- a/layers/place-city-rank10.yml
+++ b/layers/place-city-rank10.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank2.yml
+++ b/layers/place-city-rank2.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank3.yml
+++ b/layers/place-city-rank3.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank4.yml
+++ b/layers/place-city-rank4.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 9
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank5.yml
+++ b/layers/place-city-rank5.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 10
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank6.yml
+++ b/layers/place-city-rank6.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 11
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank7.yml
+++ b/layers/place-city-rank7.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank8.yml
+++ b/layers/place-city-rank8.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-city-rank9.yml
+++ b/layers/place-city-rank9.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8
+maxzoom: 13
 filter:
   - all
   - - '!='

--- a/layers/place-town.yml
+++ b/layers/place-town.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 8.5
+maxzoom: 13
 filter:
   - all
   - - '=='

--- a/layers/place-village.yml
+++ b/layers/place-village.yml
@@ -3,6 +3,7 @@ type: symbol
 source: geolonia-gsi-custom
 source-layer: place
 minzoom: 9
+maxzoom: 13
 filter:
   - all
   - - '=='


### PR DESCRIPTION
Close #149 

首都の maxzoom を 11に、その他の地名を 13 に設定